### PR TITLE
dash: Adjust close locks

### DIFF
--- a/src/dash.c
+++ b/src/dash.c
@@ -769,8 +769,9 @@ void dash_init()
 void dash_deinit()
 {
     dash_running = false;
-    jpeg_decoder_deinit();
     SDL_WaitThread(parser_thread, NULL);
+    jpeg_decoder_deinit();
+    //All threads are stopped. Dont need lvgl locks anymore.
     if (dash_config)
     {
         xml_document_free(dash_config, false);

--- a/src/main.c
+++ b/src/main.c
@@ -87,12 +87,10 @@ int main(int argc, char *argv[])
             SDL_Delay(LV_DISP_DEF_REFR_PERIOD - tick_elapsed);
         }
     }
-    lvgl_getlock();
     dash_deinit();
     lv_deinit();
     lv_port_disp_deinit();
     lv_port_indev_deinit();
-    lvgl_removelock();
     platform_quit(lv_get_quit());
     return 0;
 }


### PR DESCRIPTION
I think there's a possiblilty of a deadlock if the jpg_callback is called just after dash_deinit is called as they both try obtain the lvgl lock.