### PR TITLE
Feature: Add extended partition support

### DIFF
--- a/src/dash.c
+++ b/src/dash.c
@@ -45,7 +45,7 @@ static const char *xml_default = ""
             "\t\t\t<1>Recent</1>\n"
       "\t\t</Recent>\n"
       "\t\t<Games>\n"
-            "\t\t\t<1>A:\\Games</1>\n"
+            "\t\t\t<1>Q:\\Games</1>\n"
             "\t\t\t<2>E:\\Games</2>\n"
             "\t\t\t<3>F:\\Games</3>\n"
             "\t\t\t<4>G:\\Games</4>\n"
@@ -386,16 +386,16 @@ static void game_parser_task(parse_handle_t *p)
     // We found a folder (Folders begin with '/' in lvgl)
     if (fname[0] == '/')
     {
-        // cwd should look like A:PARSE_DIR
+        // cwd should look like Q:PARSE_DIR
         len = strlen(p->cwd);
         char *end = &p->cwd[len];
         *end = DASH_PATH_SEPARATOR;
         end++;
         strcpy(end, &fname[1]); // Skip the first '/' symbol
-        // cwd should look like A:PARSE_DIR\SUB_DIR
+        // cwd should look like Q:PARSE_DIR\SUB_DIR
 
         lv_snprintf(fname, sizeof(fname), "%s%c%s", p->cwd, DASH_PATH_SEPARATOR, DASH_LAUNCH_EXE);
-        //fname should look like A:PARSE_DIR\SUB_DIR\DASH_LAUNCH_EXE
+        //fname should look like Q:PARSE_DIR\SUB_DIR\DASH_LAUNCH_EXE
         if (lv_fs_exists(fname))
         {
             if (lv_obj_get_child_cnt(p->scroller) == DASH_MAX_GAMES)

--- a/src/dash.h
+++ b/src/dash.h
@@ -22,21 +22,21 @@ extern "C" {
 #endif
 
 
-//All lvgl directories are prefixed with A:
-//nxdk local directory is also mounting to A: so we get A:A:..
+//All lvgl directories are prefixed with Q:
+//nxdk local directory is also mounting to Q: so we get Q:Q:..
 #ifndef DASH_XML
 #ifdef NXDK
-#define DASH_XML "A:A:\\dash.xml"
+#define DASH_XML "Q:Q:\\dash.xml"
 #else
-#define DASH_XML "A:dash.xml"
+#define DASH_XML "Q:dash.xml"
 #endif
 #endif
 
 #ifndef RECENT_TITLES
 #ifdef NXDK
-#define RECENT_TITLES "A:E:\\UDATA\\LithiumX\\recent.dat"
+#define RECENT_TITLES "Q:E:\\UDATA\\LithiumX\\recent.dat"
 #else
-#define RECENT_TITLES "A:recent.dat"
+#define RECENT_TITLES "Q:recent.dat"
 #endif
 #endif
 

--- a/src/dash_eeprom.c
+++ b/src/dash_eeprom.c
@@ -96,7 +96,7 @@ static void eeprom_backup(lv_obj_t *obj)
     }
     lv_fs_file_t fp;
     uint32_t bw;
-    if (lv_fs_open(&fp, "A:E:\\eeprom.bin", LV_FS_MODE_WR) == LV_FS_RES_OK)
+    if (lv_fs_open(&fp, "Q:E:\\eeprom.bin", LV_FS_MODE_WR) == LV_FS_RES_OK)
     {
         lv_fs_write(&fp, buffer, sizeof(buffer), &bw);
         lv_fs_close(&fp);

--- a/src/dash_filebrowser.c
+++ b/src/dash_filebrowser.c
@@ -13,10 +13,10 @@
 
 #ifdef NXDK
 #include <nxdk/mount.h>
-static const char root_drives[][3] = {"C:", "D:", "E:", "F:", "G:", "X:", "Y:", "Z:"};
-#define ROOT_PATH "A:"
+static const char root_drives[][3] = {"C:", "D:", "E:", "F:", "G:", "R:", "S:", "V:", "W:", "A:", "B:", "P:", "X:", "Y:", "Z:"};
+#define ROOT_PATH "Q:"
 #else
-#define ROOT_PATH "A:."
+#define ROOT_PATH "Q:."
 #endif
 static uint8_t row_stack[256];
 static uint8_t row_stack_i;

--- a/src/dash_filebrowser.c
+++ b/src/dash_filebrowser.c
@@ -154,7 +154,7 @@ static void table_key(lv_event_t *e)
                                       sizeof(LV_SYMBOL_DIRECTORY) + 1];
         if (strstr(cell_str, LV_SYMBOL_DIRECTORY))
         {
-            // Should now have "A:cwd"
+            // Should now have "Q:cwd"
             int end = strlen(cwd);
 #ifdef NXDK
             if (strcmp(ROOT_PATH, cwd) != 0)
@@ -162,9 +162,9 @@ static void table_key(lv_event_t *e)
             {
                 cwd[end++] = DASH_PATH_SEPARATOR;
             }
-            // Should now have "A:cwd/"
+            // Should now have "Q:cwd/"
             strcpy(&cwd[end], fname);
-            // Should now have "A:cwd/newfolder"
+            // Should now have "Q:cwd/newfolder"
 
             // List the new directory.
             if (!list_dir(obj))

--- a/src/platform/xbox/platform.c
+++ b/src/platform/xbox/platform.c
@@ -78,21 +78,36 @@ void platform_init(int *w, int *h)
         nxUnmountDrive('D');
     }
 
-    /*Remount root xbe path to A:\\*/
+    /*Remount root xbe path to Q:\\*/
     char targetPath[MAX_PATH];
     nxGetCurrentXbeNtPath(targetPath);
     char *finalSeparator = strrchr(targetPath, '\\');
     *(finalSeparator + 1) = '\0';
-    nxMountDrive('A', targetPath);
+    nxMountDrive('Q', targetPath);
 
+    // Mount the DVD drive
     nxMountDrive('D', "\\Device\\CdRom0");
+
+    // Mount stock partitions
     nxMountDrive('C', "\\Device\\Harddisk0\\Partition2\\");
     nxMountDrive('E', "\\Device\\Harddisk0\\Partition1\\");
-    nxMountDrive('F', "\\Device\\Harddisk0\\Partition6\\");
-    nxMountDrive('G', "\\Device\\Harddisk0\\Partition7\\");
     nxMountDrive('X', "\\Device\\Harddisk0\\Partition3\\");
     nxMountDrive('Y', "\\Device\\Harddisk0\\Partition4\\");
     nxMountDrive('Z', "\\Device\\Harddisk0\\Partition5\\");
+
+    // Mount extended partitions
+    // NOTE: Both the retail kernel and modified kernels will mount these partitions
+    // if they exist and silently fail if they don't. So we can just try to mount them
+    // and not worry about checking if they exist.
+    nxMountDrive('F', "\\Device\\Harddisk0\\Partition6\\");
+    nxMountDrive('G', "\\Device\\Harddisk0\\Partition7\\");
+    nxMountDrive('R', "\\Device\\Harddisk0\\Partition8\\");
+    nxMountDrive('S', "\\Device\\Harddisk0\\Partition9\\");
+    nxMountDrive('V', "\\Device\\Harddisk0\\Partition10\\");
+    nxMountDrive('W', "\\Device\\Harddisk0\\Partition11\\");
+    nxMountDrive('A', "\\Device\\Harddisk0\\Partition12\\");
+    nxMountDrive('B', "\\Device\\Harddisk0\\Partition13\\");
+    nxMountDrive('P', "\\Device\\Harddisk0\\Partition14\\");
 
     CreateDirectoryA("E:\\UDATA", NULL);
     CreateDirectoryA("E:\\UDATA\\LithiumX", NULL);
@@ -190,7 +205,7 @@ const char *platform_realtime_info_cb(void)
         {"Jan", "Feb", "Mar", "Apr", "May", "Jun",
          "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
 
-    // Read System time, adjust for timezone offset then convert to time fields. 
+    // Read System time, adjust for timezone offset then convert to time fields.
     TIME_FIELDS tf;
     LARGE_INTEGER lt;
     LONG timezone, daylight;


### PR DESCRIPTION
This adds extended partition support based on past homebrew naming schemes. 

In addition, the FTP root directory look-up has been extended to only return drives that are mounted.

And lastly, this PR changes the default root/launch drive from A to Q to avoid a conflict with partition 12. This part needs to be tested a bit more as I'm not completely familiar with the parts of the code base that it touches.