### PR TITLE
xbox: Cache remainder of platform items

### DIFF
--- a/src/platform/xbox/xbox_info.h
+++ b/src/platform/xbox/xbox_info.h
@@ -90,10 +90,8 @@ static const char *xbox_get_verion()
     return ver_string;
 }
 
-static const char *tray_state_str()
+static const char *tray_state_str(ULONG tray_state)
 {
-    ULONG tray_state = 0x70;
-    HalReadSMCTrayState(&tray_state, NULL);
     switch (tray_state & 0x70)
     {
     case 0x00:


### PR DESCRIPTION
Kind of follows from https://github.com/Ryzee119/LithiumX/pull/36

Caches remainder of non-volatile strings - things that access EEPROM are slow and block GUI thread.
Dont call GetLocalTime every second - this is slow and has lots of EEPROM access ( it now reads once then calculates using ticks) - will read the EEPROM the first time or once a day.
Moved the temp reading from ADM out of gui thread

Platform info screen GUI CPU time is basically the same as most idle screens now
