### PR TITLE
Rendering tweaks

### DIFF
--- a/src/lvgl_drivers/video/xgu/lv_xgu_disp.c
+++ b/src/lvgl_drivers/video/xgu/lv_xgu_disp.c
@@ -17,7 +17,6 @@ uint32_t *p;
 
 static void end_frame()
 {
-    pb_end(p);
     while (pb_finished());
 }
 
@@ -28,6 +27,7 @@ static void begin_frame()
     p = pb_begin();
     p = xgu_set_color_clear_value(p, 0xff000000);
     p = xgu_clear_surface(p, XGU_CLEAR_Z | XGU_CLEAR_STENCIL | XGU_CLEAR_COLOR);
+    pb_end(p);
 }
 
 void lvgl_getlock(void);

--- a/src/lvgl_drivers/video/xgu/lv_xgu_rect.c
+++ b/src/lvgl_drivers/video/xgu/lv_xgu_rect.c
@@ -120,6 +120,8 @@ void xgu_draw_rect(lv_draw_ctx_t *draw_ctx, const lv_draw_rect_dsc_t *dsc, const
         return;
     }
 
+    p = pb_begin();
+
     if (xgu_ctx->xgu_data->combiner_mode != 0)
     {
         #include "lvgl_drivers/video/xgu/notexture.inl"
@@ -174,6 +176,8 @@ void xgu_draw_rect(lv_draw_ctx_t *draw_ctx, const lv_draw_rect_dsc_t *dsc, const
 
     rect_draw_image(&draw_area, dsc);
     rect_draw_border(&draw_area, dsc);
+
+    pb_end(p);
 }
 
 void xgu_draw_bg(struct _lv_draw_ctx_t *draw_ctx, const lv_draw_rect_dsc_t *draw_dsc, const lv_area_t *src_area)

--- a/src/lvgl_drivers/video/xgu/lv_xgu_texture.c
+++ b/src/lvgl_drivers/video/xgu/lv_xgu_texture.c
@@ -203,12 +203,6 @@ void xgu_draw_letter(struct _lv_draw_ctx_t *draw_ctx, const lv_draw_label_dsc_t 
         return;
     }
 
-    if (xgu_ctx->xgu_data->combiner_mode != 1)
-    {
-        #include "lvgl_drivers/video/xgu/texture.inl"
-        xgu_ctx->xgu_data->combiner_mode = 1;
-    }
-
     lv_lru_get(xgu_ctx->xgu_data->texture_cache, &bmp, sizeof(bmp), (void **)&texture);
     if (texture == NULL)
     {
@@ -229,12 +223,21 @@ void xgu_draw_letter(struct _lv_draw_ctx_t *draw_ctx, const lv_draw_label_dsc_t 
         }
     }
 
+    p = pb_begin();
+
+    if (xgu_ctx->xgu_data->combiner_mode != 1)
+    {
+        #include "lvgl_drivers/video/xgu/texture.inl"
+        xgu_ctx->xgu_data->combiner_mode = 1;
+    }
+
     p = xgux_set_color4ub(p, dsc->color.ch.red, dsc->color.ch.green,
                           dsc->color.ch.blue, dsc->opa);
 
     bind_texture(xgu_ctx, texture, (uint32_t)bmp, XGU_TEXTURE_FILTER_LINEAR);
 
     map_textured_rect(texture, &letter_area, &draw_area, 256.0f);
+    pb_end(p);
 }
 
 lv_res_t xgu_draw_img(struct _lv_draw_ctx_t *draw_ctx, const lv_draw_img_dsc_t *dsc,
@@ -297,6 +300,7 @@ void xgu_draw_img_decoded(struct _lv_draw_ctx_t *draw_ctx, const lv_draw_img_dsc
 
     lv_color_t recolor = lv_color_make(255, 255, 255);
 
+    p = pb_begin();
     // If we are about the draw 1 bit indexed image. Setup draw color froms src_buf;
     if (cf == LV_IMG_CF_INDEXED_1BIT)
     {
@@ -381,6 +385,7 @@ void xgu_draw_img_decoded(struct _lv_draw_ctx_t *draw_ctx, const lv_draw_img_dsc
         }
         if (texture == NULL)
         {
+            pb_end(p);
             return;
         }
     }
@@ -399,4 +404,5 @@ void xgu_draw_img_decoded(struct _lv_draw_ctx_t *draw_ctx, const lv_draw_img_dsc
                  (dsc->antialias) ? XGU_TEXTURE_FILTER_LINEAR : XGU_TEXTURE_FILTER_NEAREST);
 
     map_textured_rect(texture, &src_area_transformed, &draw_area, (float)dsc->zoom);
+    pb_end(p);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -145,12 +145,16 @@ int main(int argc, char* argv[]) {
         lvgl_getlock();
         lv_task_handler();
         lvgl_removelock();
+        #ifdef NXDK
+        pb_wait_for_vbl();
+        #else
         e = SDL_GetTicks();
         t = e - s;
         if (t < LV_DISP_DEF_REFR_PERIOD)
         {
             SDL_Delay(LV_DISP_DEF_REFR_PERIOD - t);
         }
+        #endif
     }
     dash_printf(LEVEL_TRACE, "Quitting dash with quit event %d\n", lv_get_quit());
     lv_port_disp_deinit();


### PR DESCRIPTION
I was getting "pb_push_to: begin-end block musn't exceed 128 dwords" log spam when I enabled logging. I was sending way more than 128  DWORDs which seemed to work okay so not sure why the limit but I meet it now mostly anyway

Also I think I have fixed the random flickering by waiting on the vblank event instead of manual frame timing.

pkbit now uses two buffers instead of 3 (saves ~3.5MB of RAM in 720p)