### PR TITLE
Ftp fix

### DIFF
--- a/src/libs/ftpd/ftp_file.c
+++ b/src/libs/ftpd/ftp_file.c
@@ -388,8 +388,8 @@ FRESULT ftps_f_close(FIL *fp)
 		FILE_END_OF_FILE_INFORMATION endOfFile;
 		FILE_ALLOCATION_INFORMATION allocation;
 
-		endOfFile.EndOfFile.QuadPart = fp->write_total;
-		allocation.AllocationSize.QuadPart = fp->write_total;
+		endOfFile.EndOfFile.QuadPart = (ULONGLONG)fp->write_total;
+		allocation.AllocationSize.QuadPart = (ULONGLONG)fp->write_total;
 		status = NtSetInformationFile(hfile, &iostatusBlock, &endOfFile, sizeof(endOfFile), FileEndOfFileInformation);
 		if (!NT_SUCCESS(status))
 			FILE_DBG("Error setting File End information");

--- a/src/libs/ftpd/ftp_file.h
+++ b/src/libs/ftpd/ftp_file.h
@@ -41,8 +41,8 @@ typedef struct
     HANDLE cache_mutex[2];
     HANDLE write_thread;
     int thread_running;
-    int write_total;
-    int bytes_cached;
+    LONGLONG write_total;
+    LONGLONG bytes_cached;
     int pre_alloc;
 } fil_handle_t;
 

--- a/src/lvgl_drivers/video/xgu/lv_xgu_disp.c
+++ b/src/lvgl_drivers/video/xgu/lv_xgu_disp.c
@@ -17,7 +17,6 @@ uint32_t *p;
 
 static void end_frame()
 {
-    pb_end(p);
     while (pb_finished());
 }
 
@@ -28,6 +27,7 @@ static void begin_frame()
     p = pb_begin();
     p = xgu_set_color_clear_value(p, 0xff000000);
     p = xgu_clear_surface(p, XGU_CLEAR_Z | XGU_CLEAR_STENCIL | XGU_CLEAR_COLOR);
+    pb_end(p);
 }
 
 void lvgl_getlock(void);

--- a/src/lvgl_drivers/video/xgu/lv_xgu_rect.c
+++ b/src/lvgl_drivers/video/xgu/lv_xgu_rect.c
@@ -120,6 +120,8 @@ void xgu_draw_rect(lv_draw_ctx_t *draw_ctx, const lv_draw_rect_dsc_t *dsc, const
         return;
     }
 
+    p = pb_begin();
+
     if (xgu_ctx->xgu_data->combiner_mode != 0)
     {
         #include "lvgl_drivers/video/xgu/notexture.inl"
@@ -174,6 +176,8 @@ void xgu_draw_rect(lv_draw_ctx_t *draw_ctx, const lv_draw_rect_dsc_t *dsc, const
 
     rect_draw_image(&draw_area, dsc);
     rect_draw_border(&draw_area, dsc);
+
+    pb_end(p);
 }
 
 void xgu_draw_bg(struct _lv_draw_ctx_t *draw_ctx, const lv_draw_rect_dsc_t *draw_dsc, const lv_area_t *src_area)

--- a/src/lvgl_drivers/video/xgu/lv_xgu_texture.c
+++ b/src/lvgl_drivers/video/xgu/lv_xgu_texture.c
@@ -203,12 +203,6 @@ void xgu_draw_letter(struct _lv_draw_ctx_t *draw_ctx, const lv_draw_label_dsc_t 
         return;
     }
 
-    if (xgu_ctx->xgu_data->combiner_mode != 1)
-    {
-        #include "lvgl_drivers/video/xgu/texture.inl"
-        xgu_ctx->xgu_data->combiner_mode = 1;
-    }
-
     lv_lru_get(xgu_ctx->xgu_data->texture_cache, &bmp, sizeof(bmp), (void **)&texture);
     if (texture == NULL)
     {
@@ -229,12 +223,21 @@ void xgu_draw_letter(struct _lv_draw_ctx_t *draw_ctx, const lv_draw_label_dsc_t 
         }
     }
 
+    p = pb_begin();
+
+    if (xgu_ctx->xgu_data->combiner_mode != 1)
+    {
+        #include "lvgl_drivers/video/xgu/texture.inl"
+        xgu_ctx->xgu_data->combiner_mode = 1;
+    }
+
     p = xgux_set_color4ub(p, dsc->color.ch.red, dsc->color.ch.green,
                           dsc->color.ch.blue, dsc->opa);
 
     bind_texture(xgu_ctx, texture, (uint32_t)bmp, XGU_TEXTURE_FILTER_LINEAR);
 
     map_textured_rect(texture, &letter_area, &draw_area, 256.0f);
+    pb_end(p);
 }
 
 lv_res_t xgu_draw_img(struct _lv_draw_ctx_t *draw_ctx, const lv_draw_img_dsc_t *dsc,
@@ -297,6 +300,7 @@ void xgu_draw_img_decoded(struct _lv_draw_ctx_t *draw_ctx, const lv_draw_img_dsc
 
     lv_color_t recolor = lv_color_make(255, 255, 255);
 
+    p = pb_begin();
     // If we are about the draw 1 bit indexed image. Setup draw color froms src_buf;
     if (cf == LV_IMG_CF_INDEXED_1BIT)
     {
@@ -381,6 +385,7 @@ void xgu_draw_img_decoded(struct _lv_draw_ctx_t *draw_ctx, const lv_draw_img_dsc
         }
         if (texture == NULL)
         {
+            pb_end(p);
             return;
         }
     }
@@ -399,4 +404,5 @@ void xgu_draw_img_decoded(struct _lv_draw_ctx_t *draw_ctx, const lv_draw_img_dsc
                  (dsc->antialias) ? XGU_TEXTURE_FILTER_LINEAR : XGU_TEXTURE_FILTER_NEAREST);
 
     map_textured_rect(texture, &src_area_transformed, &draw_area, (float)dsc->zoom);
+    pb_end(p);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -145,12 +145,16 @@ int main(int argc, char* argv[]) {
         lvgl_getlock();
         lv_task_handler();
         lvgl_removelock();
+        #ifdef NXDK
+        pb_wait_for_vbl();
+        #else
         e = SDL_GetTicks();
         t = e - s;
         if (t < LV_DISP_DEF_REFR_PERIOD)
         {
             SDL_Delay(LV_DISP_DEF_REFR_PERIOD - t);
         }
+        #endif
     }
     dash_printf(LEVEL_TRACE, "Quitting dash with quit event %d\n", lv_get_quit());
     lv_port_disp_deinit();


### PR DESCRIPTION
https://github.com/Ryzee119/LithiumX/issues/38

two fold problem - files that were a non integer page size follow a slightly different code path when the file is closed. Also overflow issue due to the filesize being larger than 32bit signed integer.

Both the above had to be true which could result in a corrupt file