### PR TITLE
Implement REST command

### DIFF
--- a/src/libs/ftpd/ftp_file.c
+++ b/src/libs/ftpd/ftp_file.c
@@ -443,9 +443,10 @@ FRESULT ftps_f_write(FIL *fp, const void *buffer, uint32_t buflen, uint32_t *wri
 	return res;
 }
 
-FRESULT ftps_f_read(FIL *fp, void *buffer, uint32_t len, uint32_t *read)
+FRESULT ftps_f_read(FIL *fp, void *buffer, uint32_t len, uint32_t *read, uint32_t position)
 {
 	HANDLE hfile = fp->h;
+	SetFilePointer(hfile, position, NULL, FILE_BEGIN);
 	return (ReadFile(hfile, (LPVOID)buffer, len, (LPDWORD)read, NULL)) ? FR_OK : FR_INVALID_PARAMETER;
 }
 

--- a/src/libs/ftpd/ftp_file.h
+++ b/src/libs/ftpd/ftp_file.h
@@ -99,7 +99,7 @@ FRESULT ftps_f_open(FIL *fp, const char *path, uint8_t mode);
 size_t ftps_f_size(FIL *fp);
 FRESULT ftps_f_close(FIL *fp);
 FRESULT ftps_f_write(FIL *fp, const void *buffer, uint32_t len, uint32_t *written);
-FRESULT ftps_f_read(FIL *fp, void *buffer, uint32_t len, uint32_t *read);
+FRESULT ftps_f_read(FIL *fp, void *buffer, uint32_t len, uint32_t *read, uint32_t position);
 FRESULT ftps_f_mkdir(const char *path);
 FRESULT ftps_f_rename(const char *from, const char *to);
 FRESULT ftps_f_utime(const char *path, const FILINFO *fno);

--- a/src/libs/ftpd/ftp_server.h
+++ b/src/libs/ftpd/ftp_server.h
@@ -101,6 +101,9 @@ typedef struct {
 
 	// data connection mode state
 	dcm_type data_conn_mode;
+
+	// file restart position
+	uint32_t file_restart_pos;
 } ftp_data_t;
 
 // structure for ftp commands


### PR DESCRIPTION
This implements the restart command which allows for resuming interrupted file reads, or in my case, abusing the protocol for efficient file seeking and partial reading. It also fixes a bug in `ftp_cmd_retr` where a file would continue to be read/transferred after aborting the connection client-side.