### PR TITLE
xbox: Disable network interrupts on platform_quit()

### DIFF
--- a/src/platform/xbox/platform.c
+++ b/src/platform/xbox/platform.c
@@ -188,7 +188,7 @@ void platform_launch_iso(const char *path);
 
 void platform_quit(lv_quit_event_t event)
 {
-    nvnetdrv_stop_txrx();
+    nvnetdrv_stop();
     usbh_core_deinit();
     debugClearScreen();
 


### PR DESCRIPTION
Resolves certain network enabled titles from freezing on boot.

IonBlade over on the MakeMHz Discord server [reported](https://discord.com/channels/643467096906399804/1185794478389329951/1191550695543935127) that ``Ford Racing 3`` and ``Sega GT Online`` do not work when launched from LithiumX.

This is a simple fix that replaces the call to ``nvnetdrv_stop_txrx()`` with ``nvnetdrv_stop()``. This should disable the NIC interrupts and stop Tx/Rx.

Both titles appear to be working correctly after the change.